### PR TITLE
Allow links like auth to auto open in browser

### DIFF
--- a/lib/console_tweet/cli.rb
+++ b/lib/console_tweet/cli.rb
@@ -48,6 +48,7 @@ module ConsoleTweet
       request_token = @client.request_token
       # ask the user to visit the auth url
       puts "To authenticate your client, visit the URL: #{request_token.authorize_url}"
+      open_link request_token.authorize_url
       # wait for the user to give us the PIN back
       print 'Enter PIN: '
       begin
@@ -228,6 +229,14 @@ module ConsoleTweet
       tweets.each do |tweet|
         puts "#{tweet['text']}\n#{NameColor}@#{tweet['user']['screen_name']} (#{tweet['user']['name']})#{DefaultColor}\n\n"
       end
+    end
+
+    def open_link url
+      exec "open #{url}" if is_mac?
+    end
+
+    def is_mac?
+      RUBY_PLATFORM.downcase.include?("darwin")
     end
 
   end


### PR DESCRIPTION
When ran on a mac OS, the auth request automatically opens in the default browser.
- Add method `open_link` to use mac `open` command line only if mac
  - This could be reused to open any tweet ref/user/etc
  - If users of other OS's know how to get it to auth-open then they can just add to this method
- Add method `is_mac` to determine if its a mac OS
  - Other `is_` need adding as required
